### PR TITLE
Put with options

### DIFF
--- a/examples/search.rb
+++ b/examples/search.rb
@@ -24,24 +24,26 @@ response = client.search(
   CollectionSpace::Search.new.from_hash(search_args),
   { sortBy: 'collectionspace_core:updatedAt DESC' }
 )
-response.parsed['abstract_common_list']['list_item'].map do |i|
-  puts i['uri']
-end if response.result.success?
+if response.result.success?
+  response.parsed['abstract_common_list']['list_item'].map do |i|
+    puts i['uri']
+  end
+end
 
-puts "Search: QA TEST 001"
+puts 'Search: QA TEST 001'
 response = client.find(type: 'collectionobjects', value: 'QA TEST 001')
 ap response.parsed['abstract_common_list'] if response.result.success?
 
 [
-  {type: 'placeauthorities', subtype: 'place', value: 'California'},
-  {type: 'placeauthorities', subtype: 'place', value: 'Death Valley'},
-  {type: 'placeauthorities', subtype: 'place', value: 'Hamilton!, Ohio'},
-  {type: 'placeauthorities', subtype: 'place', value: '姫路城'},
-  {type: 'placeauthorities', subtype: 'place', value: "No'Where"},
-  {type: 'personauthorities', subtype: 'person', value: 'Morris, Perry(Pete)'},
-  {type: 'personauthorities', subtype: 'person', value: 'Clark, H. Pol & Mary Gambo'},
-  {type: 'orgauthorities', subtype: 'organization', value: "Smith's Appletree Garager"},
-  {type: 'orgauthorities', subtype: 'organization', value: 'The "Grand" Canyon'},
+  { type: 'placeauthorities', subtype: 'place', value: 'California' },
+  { type: 'placeauthorities', subtype: 'place', value: 'Death Valley' },
+  { type: 'placeauthorities', subtype: 'place', value: 'Hamilton!, Ohio' },
+  { type: 'placeauthorities', subtype: 'place', value: '姫路城' },
+  { type: 'placeauthorities', subtype: 'place', value: "No'Where" },
+  { type: 'personauthorities', subtype: 'person', value: 'Morris, Perry(Pete)' },
+  { type: 'personauthorities', subtype: 'person', value: 'Clark, H. Pol & Mary Gambo' },
+  { type: 'orgauthorities', subtype: 'organization', value: "Smith's Appletree Garager" },
+  { type: 'orgauthorities', subtype: 'organization', value: 'The "Grand" Canyon' }
 ].each do |term|
   puts "Search: #{term[:value]}"
   response = client.find(

--- a/lib/collectionspace/client/client.rb
+++ b/lib/collectionspace/client/client.rb
@@ -23,9 +23,9 @@ module CollectionSpace
       request 'POST', path, { body: payload }.merge(options)
     end
 
-    def put(path, payload)
+    def put(path, payload, options = {})
       check_payload(payload)
-      request 'PUT', path, body: payload
+      request 'PUT', path, { body: payload }.merge(options)
     end
 
     def delete(path)

--- a/lib/collectionspace/client/helpers.rb
+++ b/lib/collectionspace/client/helpers.rb
@@ -11,9 +11,7 @@ module CollectionSpace
 
       Enumerator::Lazy.new(0...iterations) do |yielder, i|
         response = request('GET', path, options.merge(query: { pgNum: i }))
-        unless response.result.success?
-          raise CollectionSpace::RequestError, response.result.body
-        end
+        raise CollectionSpace::RequestError, response.result.body unless response.result.success?
 
         items_in_page = response.parsed[list_type].fetch('itemsInPage', 0).to_i
         list_items = items_in_page.positive? ? response.parsed[list_type][list_item] : []
@@ -26,9 +24,7 @@ module CollectionSpace
     def count(path)
       list_type, = get_list_types(path)
       response   = request('GET', path, query: { pgNum: 0, pgSz: 1 })
-      unless response.result.success?
-        raise CollectionSpace::RequestError, response.result.body
-      end
+      raise CollectionSpace::RequestError, response.result.body unless response.result.success?
 
       response.parsed[list_type]['totalItems'].to_i
     end
@@ -37,9 +33,8 @@ module CollectionSpace
     def domain
       path = 'personauthorities'
       response = request('GET', path, query: { pgNum: 0, pgSz: 1 })
-      unless response.result.success?
-        raise CollectionSpace::RequestError, response.result.body
-      end
+      raise CollectionSpace::RequestError, response.result.body unless response.result.success?
+
       refname = response.parsed.dig(*get_list_types(path), 'refName')
       CollectionSpace::RefName.parse(refname)[:domain]
     end

--- a/lib/collectionspace/client/version.rb
+++ b/lib/collectionspace/client/version.rb
@@ -2,6 +2,6 @@
 
 module CollectionSpace
   class Client
-    VERSION = '0.8.0'
+    VERSION = '0.9.0'
   end
 end

--- a/spec/collectionspace/helpers_spec.rb
+++ b/spec/collectionspace/helpers_spec.rb
@@ -33,6 +33,6 @@ describe CollectionSpace::Helpers do
         success?: true
       )
     )
-    expect(client.domain).to eq("core.collectionspace.org")
+    expect(client.domain).to eq('core.collectionspace.org')
   end
 end

--- a/spec/collectionspace/refname_spec.rb
+++ b/spec/collectionspace/refname_spec.rb
@@ -18,39 +18,39 @@ describe CollectionSpace::RefName do
 
   it 'can parse a top level authority refname' do
     expect(CollectionSpace::RefName.parse(refname_authority)).to eq({
-      domain: 'core.collectionspace.org',
-      type: 'personauthorities',
-      subtype: 'person',
-    })
+                                                                      domain: 'core.collectionspace.org',
+                                                                      type: 'personauthorities',
+                                                                      subtype: 'person'
+                                                                    })
   end
 
   it 'can parse an authority term refname' do
     expect(CollectionSpace::RefName.parse(refname_person)).to eq({
-      domain: 'core.collectionspace.org',
-      type: 'personauthorities',
-      subtype: 'person',
-      identifier: '1234561562130996026',
-      label: '123456'
-    })
+                                                                   domain: 'core.collectionspace.org',
+                                                                   type: 'personauthorities',
+                                                                   subtype: 'person',
+                                                                   identifier: '1234561562130996026',
+                                                                   label: '123456'
+                                                                 })
   end
 
   it 'can parse an authority term with colon' do
     expect(CollectionSpace::RefName.parse(refname_with_colon_in_name)).to eq({
-      domain: 'core.collectionspace.org',
-      type: 'locationauthorities',
-      subtype: 'location',
-      identifier: 'AR1U1Shelf14078111602',
-      label: 'A:R1:U1:Shelf 1'
-    })
+                                                                               domain: 'core.collectionspace.org',
+                                                                               type: 'locationauthorities',
+                                                                               subtype: 'location',
+                                                                               identifier: 'AR1U1Shelf14078111602',
+                                                                               label: 'A:R1:U1:Shelf 1'
+                                                                             })
   end
 
   it 'can parse an authority term with parens' do
     expect(CollectionSpace::RefName.parse(refname_with_parens)).to eq({
-      domain: 'core.collectionspace.org',
-      type: 'conceptauthorities',
-      subtype: 'concept',
-      identifier: 'JMAlexanderCompanyAtlantaGa1028284796',
-      label: 'J.M. Alexander & Company (Atlanta, Ga.)'
-    })
+                                                                        domain: 'core.collectionspace.org',
+                                                                        type: 'conceptauthorities',
+                                                                        subtype: 'concept',
+                                                                        identifier: 'JMAlexanderCompanyAtlantaGa1028284796',
+                                                                        label: 'J.M. Alexander & Company (Atlanta, Ga.)'
+                                                                      })
   end
 end


### PR DESCRIPTION
Adds ability to pass optional options hash to `Client.put`

This is added to support batch addition of blobs to media records that do not already have blobs, via `collectionspace-csv-importer`

I have tested that it works as expected with a local copy of this PR.