### PR TITLE
Parse more refname types, resolves #19

### DIFF
--- a/lib/collectionspace/client/refname.rb
+++ b/lib/collectionspace/client/refname.rb
@@ -4,18 +4,39 @@ module CollectionSpace
   # CollectionSpace RefName
   class RefName
     def self.parse(refname)
-      parts = refname.split(':')
+      parts   = refname.split(':')
+      subpart = parts[4] =~ /^id/ ? :identifier : :subtype
+      nilpart = parts[4] =~ /^id/ ? :subtype    : :identifier
+
       parsed = {
         domain: parts[2],
         type: parts[3],
-        subtype: parts[4].match(/\((.*)\)/).captures[0]
+        subpart => between_parens(parts[4]),
+        nilpart => nil
       }
+      parsed[:label] = between_single_quotes(parts[4])
+
       if parts.length > 5
         parts[6] = parts[6..parts.length].join(':') if parts.length > 7
-        parsed[:identifier] = parts[6].match(/\((.*?)\)/).captures[0]
-        parsed[:label] = parts[6].match(/'(.*)'/).captures[0]
+        parsed[:identifier] = between_parens(parts[6])
+        parsed[:label] = between_single_quotes(parts[6])
       end
+
       parsed
+    end
+
+    def self.between_parens(part)
+      regex_capture_first(/\((.*?)\)/, part)
+    end
+
+    def self.between_single_quotes(part)
+      regex_capture_first(/'(.*)'/, part)
+    end
+
+    def self.regex_capture_first(regex, part)
+      return nil unless part.match(regex)
+
+      part.match(regex).captures[0]
     end
   end
 end

--- a/spec/collectionspace/refname_spec.rb
+++ b/spec/collectionspace/refname_spec.rb
@@ -3,6 +3,15 @@
 require 'spec_helper'
 
 describe CollectionSpace::RefName do
+  let(:refname_collectionobject) do
+    "urn:cspace:core.collectionspace.org:collectionobjects:id(09f531bd-4f12-4c36-9f92)'Loaned object 1'"
+  end
+  let(:refname_procedure) do
+    'urn:cspace:core.collectionspace.org:acquisitions:id(5043d8cc-9437-4bc7-92d1)'
+  end
+  let(:refname_relation) do
+    'urn:cspace:core.collectionspace.org:relations:id(da044bc2-9fbf-474d-803a)'
+  end
   let(:refname_authority) do
     "urn:cspace:core.collectionspace.org:personauthorities:name(person)'Local Persons'"
   end
@@ -16,11 +25,43 @@ describe CollectionSpace::RefName do
     "urn:cspace:core.collectionspace.org:conceptauthorities:name(concept):item:name(JMAlexanderCompanyAtlantaGa1028284796)'J.M. Alexander & Company (Atlanta, Ga.)'"
   end
 
+  it 'can parse a collectionobject refname' do
+    expect(CollectionSpace::RefName.parse(refname_collectionobject)).to eq({
+                                                                             domain: 'core.collectionspace.org',
+                                                                             type: 'collectionobjects',
+                                                                             subtype: nil,
+                                                                             identifier: '09f531bd-4f12-4c36-9f92',
+                                                                             label: 'Loaned object 1'
+                                                                           })
+  end
+
+  it 'can parse a procedure refname' do
+    expect(CollectionSpace::RefName.parse(refname_procedure)).to eq({
+                                                                      domain: 'core.collectionspace.org',
+                                                                      type: 'acquisitions',
+                                                                      subtype: nil,
+                                                                      identifier: '5043d8cc-9437-4bc7-92d1',
+                                                                      label: nil
+                                                                    })
+  end
+
+  it 'can parse a relation refname' do
+    expect(CollectionSpace::RefName.parse(refname_relation)).to eq({
+                                                                     domain: 'core.collectionspace.org',
+                                                                     type: 'relations',
+                                                                     subtype: nil,
+                                                                     identifier: 'da044bc2-9fbf-474d-803a',
+                                                                     label: nil
+                                                                   })
+  end
+
   it 'can parse a top level authority refname' do
     expect(CollectionSpace::RefName.parse(refname_authority)).to eq({
                                                                       domain: 'core.collectionspace.org',
                                                                       type: 'personauthorities',
-                                                                      subtype: 'person'
+                                                                      subtype: 'person',
+                                                                      identifier: nil,
+                                                                      label: 'Local Persons'
                                                                     })
   end
 


### PR DESCRIPTION
Additionally parse c.obj, procedure and relations refnames. Also
makes return hash consistent, containing all parts in every case.

TODO: refactor into class returning parsed RefName object:

refname.domain
refname.type
refname.subtype
refname.identifier
refname.label