### PR TITLE
Search refinements

### DIFF
--- a/examples/search.rb
+++ b/examples/search.rb
@@ -22,7 +22,7 @@ search_args = {
 puts 'Search: %D'
 response = client.search(
   CollectionSpace::Search.new.from_hash(search_args),
-  { sortBy: 'collectionspace_core:updatedAt DESC' }
+  { sortBy: CollectionSpace::Search::DEFAULT_SORT }
 )
 if response.result.success?
   response.parsed['abstract_common_list']['list_item'].map do |i|

--- a/lib/collectionspace/client/helpers.rb
+++ b/lib/collectionspace/client/helpers.rb
@@ -125,10 +125,10 @@ module CollectionSpace
       request 'GET', query.path, options
     end
 
-    def keyword_search(type:, subtype: nil, value:, sort: nil, include_deleted: false)
+    def keyword_search(type:, subtype: nil, value:, sort: nil)
       service = CollectionSpace::Service.get(type: type, subtype: subtype)
       sort ||= 'collectionspace_core:updatedAt DESC'
-      options = prepare_keyword_query(value, {sortBy: sort, wf_deleted: include_deleted})
+      options = prepare_keyword_query(value, {sortBy: sort})
       request 'GET', service[:path], options
     end
 

--- a/lib/collectionspace/client/helpers.rb
+++ b/lib/collectionspace/client/helpers.rb
@@ -56,7 +56,7 @@ module CollectionSpace
 
     # find procedure or object by type and id
     # find authority/vocab term by type, subtype, and refname
-    def find(type:, value:, subtype: nil, field: nil, schema: 'common', sort: nil)
+    def find(type:, value:, subtype: nil, field: nil, schema: 'common', sort: nil, case_sensitive: true)
       service = CollectionSpace::Service.get(type: type, subtype: subtype)
       field ||= service[:term] # this will be set if it is an authority or vocabulary, otherwise nil
       field ||= service[:identifier]
@@ -65,7 +65,7 @@ module CollectionSpace
         path: service[:path],
         namespace: "#{service[:ns_prefix]}_#{schema}",
         field: field,
-        expression: "= '#{value.gsub(/'/, '\\\\\'')}'"
+        expression: case_sensitive ? "= '#{value.gsub(/'/, '\\\\\'')}'" : "ILIKE '#{value.gsub(/'/, '\\\\\'')}'" 
       )
       search(search_args, sortBy: sort)
     end

--- a/lib/collectionspace/client/helpers.rb
+++ b/lib/collectionspace/client/helpers.rb
@@ -56,6 +56,7 @@ module CollectionSpace
 
     # find procedure or object by type and id
     # find authority/vocab term by type, subtype, and refname
+    # rubocop:disable Metrics/ParameterLists
     def find(type:, value:, subtype: nil, field: nil, schema: 'common', sort: nil, case_sensitive: true)
       service = CollectionSpace::Service.get(type: type, subtype: subtype)
       field ||= service[:term] # this will be set if it is an authority or vocabulary, otherwise nil
@@ -65,10 +66,11 @@ module CollectionSpace
         path: service[:path],
         namespace: "#{service[:ns_prefix]}_#{schema}",
         field: field,
-        expression: case_sensitive ? "= '#{value.gsub(/'/, '\\\\\'')}'" : "ILIKE '#{value.gsub(/'/, '\\\\\'')}'" 
+        expression: case_sensitive ? "= '#{value.gsub(/'/, '\\\\\'')}'" : "ILIKE '#{value.gsub(/'/, '\\\\\'')}'"
       )
       search(search_args, sortBy: sort)
     end
+    # rubocop:enable Metrics/ParameterLists
 
     def find_relation(subject_csid:, object_csid:)
       get('relations', query: { 'sbj' => subject_csid, 'obj' => object_csid })
@@ -125,10 +127,10 @@ module CollectionSpace
       request 'GET', query.path, options
     end
 
-    def keyword_search(type:, subtype: nil, value:, sort: nil)
+    def keyword_search(type:, value:, subtype: nil, sort: nil)
       service = CollectionSpace::Service.get(type: type, subtype: subtype)
       sort ||= 'collectionspace_core:updatedAt DESC'
-      options = prepare_keyword_query(value, {sortBy: sort})
+      options = prepare_keyword_query(value, { sortBy: sort })
       request 'GET', service[:path], options
     end
 

--- a/lib/collectionspace/client/helpers.rb
+++ b/lib/collectionspace/client/helpers.rb
@@ -125,6 +125,13 @@ module CollectionSpace
       request 'GET', query.path, options
     end
 
+    def keyword_search(type:, subtype: nil, value:, sort: nil, include_deleted: false)
+      service = CollectionSpace::Service.get(type: type, subtype: subtype)
+      sort ||= 'collectionspace_core:updatedAt DESC'
+      options = prepare_keyword_query(value, {sortBy: sort, wf_deleted: include_deleted})
+      request 'GET', service[:path], options
+    end
+
     def service(type:, subtype: '')
       CollectionSpace::Service.get(type: type, subtype: subtype)
     end
@@ -134,6 +141,11 @@ module CollectionSpace
     def prepare_query(query, params = {})
       query_string = "#{query.namespace}:#{query.field} #{query.expression}"
       { query: { as: query_string }.merge(params) }
+    end
+
+    def prepare_keyword_query(query, sort = {})
+      query_string = query.downcase.gsub(' ', '+')
+      { query: { kw: query_string }.merge(sort) }
     end
   end
 end

--- a/lib/collectionspace/client/search.rb
+++ b/lib/collectionspace/client/search.rb
@@ -5,6 +5,8 @@ module CollectionSpace
   class Search
     attr_accessor :path, :namespace, :field, :expression
 
+    DEFAULT_SORT = 'collectionspace_core:updatedAt DESC'
+
     def initialize(path: nil, namespace: nil, field: nil, expression: nil)
       @path       = path
       @namespace  = namespace

--- a/lib/collectionspace/client/version.rb
+++ b/lib/collectionspace/client/version.rb
@@ -2,6 +2,6 @@
 
 module CollectionSpace
   class Client
-    VERSION = '0.12.1'
+    VERSION = '0.13.0'
   end
 end

--- a/spec/collectionspace/helpers_spec.rb
+++ b/spec/collectionspace/helpers_spec.rb
@@ -38,7 +38,8 @@ describe CollectionSpace::Helpers do
   describe '#domain' do
     let(:client) { CollectionSpace::Client.new(CollectionSpace::Configuration.new) }
     it 'can get the client domain' do
-      body = '{ "abstract_common_list": { "list_item": { "refName": "urn:cspace:core.collectionspace.org:personauthorities:name(ulan_pa)\'ULAN Persons\'" } } }'
+      refname = "urn:cspace:core.collectionspace.org:personauthorities:name(ulan_pa)\'ULAN Persons\'"
+      body = %({ "abstract_common_list": { "list_item": { "refName": "#{refname}" } } })
       allow(client).to receive(:request).and_return CollectionSpace::Response.new(
         OpenStruct.new(
           code: '200',
@@ -55,7 +56,7 @@ describe CollectionSpace::Helpers do
     let(:client) { default_client }
     let(:response) { client.find(args) }
     let(:result) { response.parsed['abstract_common_list']['list_item']['uri'] }
-    
+
     context 'with object' do
       let(:args) { { type: 'collectionobjects', value: 'QA TEST 001' } }
       it 'finds as expected' do
@@ -87,7 +88,7 @@ describe CollectionSpace::Helpers do
           '/personauthorities/0f6cddfa-32ce-4c25-9b2f/items/2f050460-984b-49d7-b6df',
           '/personauthorities/0f6cddfa-32ce-4c25-9b2f/items/699abb7c-9a14-48cc-a975',
           '/orgauthorities/5225cf0b-d288-41ab-b2ea/items/02ed1508-9a29-451e-a08b',
-          '/orgauthorities/5225cf0b-d288-41ab-b2ea/items/bf51a88c-2eae-48d6-9405',
+          '/orgauthorities/5225cf0b-d288-41ab-b2ea/items/bf51a88c-2eae-48d6-9405'
         ]
         expect(results).to eq(expected)
       end
@@ -95,7 +96,9 @@ describe CollectionSpace::Helpers do
 
     context 'with vocabulary and case sensitive = false' do
       # actual value is 'additional taxa'
-      let(:args) { { type: 'vocabularies', subtype: 'annotationtype', value: 'Additional Taxa', case_sensitive: false } }
+      let(:args) do
+        { type: 'vocabularies', subtype: 'annotationtype', value: 'Additional Taxa', case_sensitive: false }
+      end
       it 'finds as expected' do
         expect(result).to eq('/vocabularies/e1401111-05c2-4d6c-bdc5/items/84c82c13-9d46-48a9-a8b9')
       end
@@ -134,23 +137,23 @@ describe CollectionSpace::Helpers do
       args = [
         { type: 'vocabularies', subtype: 'annotationtype', value: 'Additional taxa' },
         { type: 'vocabularies', subtype: 'annotationtype', value: 'ADDITIONAL TAXA' },
-        { type: 'collectionobjects', value: 'tea'},
-        { type: 'collectionobjects', value: 'set'},
-        { type: 'collectionobjects', value: 'tea set'},
+        { type: 'collectionobjects', value: 'tea' },
+        { type: 'collectionobjects', value: 'set' },
+        { type: 'collectionobjects', value: 'tea set' },
         { type: 'personauthorities', subtype: 'person', value: 'A.' },
         { type: 'personauthorities', subtype: 'person', value: 'P' },
         { type: 'personauthorities', subtype: 'person', value: 'Q.' },
         { type: 'personauthorities', subtype: 'person', value: 'Colet' },
         { type: 'personauthorities', subtype: 'person', value: 'Linda' },
         { type: 'personauthorities', subtype: 'person', value: 'Linda Colet' }
-        
+
       ]
       results = args.map { |arg| client.keyword_search(arg) }
-        .map{ |response| response.parsed['abstract_common_list']['list_item'] }
-        .map{ |list| list.is_a?(Hash) ? [list] : list } # handle single item returned
-        .map{ |list| list.nil? ? [{}] : list } # handle no items returned
-        .map{ |list| list.map{ |item| item['uri'] } }
-        .flatten
+                    .map { |response| response.parsed['abstract_common_list']['list_item'] }
+                    .map { |list| list.is_a?(Hash) ? [list] : list } # handle single item returned
+                    .map { |list| list.nil? ? [{}] : list } # handle no items returned
+                    .map { |list| list.map { |item| item['uri'] } }
+                    .flatten
 
       expected = [
         '/vocabularies/e1401111-05c2-4d6c-bdc5/items/84c82c13-9d46-48a9-a8b9',
@@ -172,7 +175,7 @@ describe CollectionSpace::Helpers do
         '/personauthorities/0f6cddfa-32ce-4c25-9b2f/items/67235e6f-5fc1-4319-b4df',
         '/personauthorities/0f6cddfa-32ce-4c25-9b2f/items/7b110f01-acac-4742-bdf0',
         '/personauthorities/0f6cddfa-32ce-4c25-9b2f/items/2fd23671-b476-4f67-b548',
-        '/personauthorities/0f6cddfa-32ce-4c25-9b2f/items/67235e6f-5fc1-4319-b4df',
+        '/personauthorities/0f6cddfa-32ce-4c25-9b2f/items/67235e6f-5fc1-4319-b4df'
       ]
       expect(results).to eq(expected)
     end

--- a/spec/collectionspace/helpers_spec.rb
+++ b/spec/collectionspace/helpers_spec.rb
@@ -94,10 +94,20 @@ describe CollectionSpace::Helpers do
       end
     end
 
-    context 'with vocabulary and case sensitive = false' do
+    context 'with vocabulary and operator = ILIKE' do
       # actual value is 'additional taxa'
       let(:args) do
-        { type: 'vocabularies', subtype: 'annotationtype', value: 'Additional Taxa', case_sensitive: false }
+        { type: 'vocabularies', subtype: 'annotationtype', value: 'Additional Taxa', operator: 'ILIKE' }
+      end
+      it 'finds as expected' do
+        expect(result).to eq('/vocabularies/e1401111-05c2-4d6c-bdc5/items/84c82c13-9d46-48a9-a8b9')
+      end
+    end
+
+    context 'with vocabulary and operator = LIKE' do
+      # actual value is 'additional taxa'
+      let(:args) do
+        { type: 'vocabularies', subtype: 'annotationtype', value: 'additional %', operator: 'LIKE' }
       end
       it 'finds as expected' do
         expect(result).to eq('/vocabularies/e1401111-05c2-4d6c-bdc5/items/84c82c13-9d46-48a9-a8b9')

--- a/spec/collectionspace/helpers_spec.rb
+++ b/spec/collectionspace/helpers_spec.rb
@@ -55,6 +55,7 @@ describe CollectionSpace::Helpers do
     let(:client) { default_client }
     let(:response) { client.find(args) }
     let(:result) { response.parsed['abstract_common_list']['list_item']['uri'] }
+    
     context 'with object' do
       let(:args) { { type: 'collectionobjects', value: 'QA TEST 001' } }
       it 'finds as expected' do
@@ -89,6 +90,14 @@ describe CollectionSpace::Helpers do
           '/orgauthorities/5225cf0b-d288-41ab-b2ea/items/bf51a88c-2eae-48d6-9405',
         ]
         expect(results).to eq(expected)
+      end
+    end
+
+    context 'with vocabulary and case sensitive = false' do
+      # actual value is 'additional taxa'
+      let(:args) { { type: 'vocabularies', subtype: 'annotationtype', value: 'Additional Taxa', case_sensitive: false } }
+      it 'finds as expected' do
+        expect(result).to eq('/vocabularies/e1401111-05c2-4d6c-bdc5/items/84c82c13-9d46-48a9-a8b9')
       end
     end
   end

--- a/spec/collectionspace/helpers_spec.rb
+++ b/spec/collectionspace/helpers_spec.rb
@@ -119,6 +119,56 @@ describe CollectionSpace::Helpers do
     end
   end
 
+  describe '#keyword_search' do
+    let(:client) { default_client }
+    it 'finds as expected' do
+      args = [
+        { type: 'vocabularies', subtype: 'annotationtype', value: 'Additional taxa' },
+        { type: 'vocabularies', subtype: 'annotationtype', value: 'ADDITIONAL TAXA' },
+        { type: 'collectionobjects', value: 'tea'},
+        { type: 'collectionobjects', value: 'set'},
+        { type: 'collectionobjects', value: 'tea set'},
+        { type: 'personauthorities', subtype: 'person', value: 'A.' },
+        { type: 'personauthorities', subtype: 'person', value: 'P' },
+        { type: 'personauthorities', subtype: 'person', value: 'Q.' },
+        { type: 'personauthorities', subtype: 'person', value: 'Colet' },
+        { type: 'personauthorities', subtype: 'person', value: 'Linda' },
+        { type: 'personauthorities', subtype: 'person', value: 'Linda Colet' }
+        
+      ]
+      results = args.map { |arg| client.keyword_search(arg) }
+        .map{ |response| response.parsed['abstract_common_list']['list_item'] }
+        .map{ |list| list.is_a?(Hash) ? [list] : list } # handle single item returned
+        .map{ |list| list.nil? ? [{}] : list } # handle no items returned
+        .map{ |list| list.map{ |item| item['uri'] } }
+        .flatten
+
+      expected = [
+        '/vocabularies/e1401111-05c2-4d6c-bdc5/items/84c82c13-9d46-48a9-a8b9',
+        '/vocabularies/e1401111-05c2-4d6c-bdc5/items/84c82c13-9d46-48a9-a8b9',
+        '/collectionobjects/ac04b8a6-db59-433e-872f',
+        '/collectionobjects/8b21c9af-1fab-4708-91d4',
+        '/collectionobjects/16e51d6a-5ae3-4716-bd0f',
+        '/collectionobjects/bf51110a-0666-47b8-b9d4',
+        '/collectionobjects/77c07515-c0e3-4b76-aeea',
+        '/collectionobjects/bf51110a-0666-47b8-b9d4',
+        '/collectionobjects/bf51110a-0666-47b8-b9d4',
+        nil,
+        '/personauthorities/0f6cddfa-32ce-4c25-9b2f/items/f7464b3c-f2a9-4c7a-bf5d',
+        '/personauthorities/0f6cddfa-32ce-4c25-9b2f/items/2661dcf8-f184-41db-b032',
+        '/personauthorities/0f6cddfa-32ce-4c25-9b2f/items/2c4e4938-482d-4574-946b',
+        '/personauthorities/0f6cddfa-32ce-4c25-9b2f/items/67235e6f-5fc1-4319-b4df',
+        '/personauthorities/0f6cddfa-32ce-4c25-9b2f/items/e4b4c37c-9243-4eb4-807b',
+        '/personauthorities/0f6cddfa-32ce-4c25-9b2f/items/e0e83104-85bc-48ba-acef',
+        '/personauthorities/0f6cddfa-32ce-4c25-9b2f/items/67235e6f-5fc1-4319-b4df',
+        '/personauthorities/0f6cddfa-32ce-4c25-9b2f/items/7b110f01-acac-4742-bdf0',
+        '/personauthorities/0f6cddfa-32ce-4c25-9b2f/items/2fd23671-b476-4f67-b548',
+        '/personauthorities/0f6cddfa-32ce-4c25-9b2f/items/67235e6f-5fc1-4319-b4df',
+      ]
+      expect(results).to eq(expected)
+    end
+  end
+
   describe '#reset_media_blob' do
     let(:client) { default_client }
     context 'with an invalid url' do


### PR DESCRIPTION
- Adds `operator` argument to `client.find`, with default value '=' for backward compatibility. `LIKE` or `ILIKE` can also be passed as `operator` argument value
- Adds a `client.keyword_search` helper method
- Moves the default sort value out of `client.find` and `client.keyword_search` methods to a constant in the `Search` class
- Bumps version to 0.13.0 since new functionality is added