### PR TITLE
`RefName.parse` can return parsed RefName object, given new optional argument

### DIFF
--- a/lib/collectionspace/client/refname.rb
+++ b/lib/collectionspace/client/refname.rb
@@ -27,7 +27,7 @@ module CollectionSpace
         parsed[:label] = between_single_quotes(parts[6])
       end
 
-      return_class == :refname_obj ? self.new(parsed) : parsed
+      return_class == :refname_obj ? new(parsed) : parsed
     end
 
     def self.between_parens(part)
@@ -45,7 +45,7 @@ module CollectionSpace
     end
 
     def initialize(parsed_hash)
-      parsed_hash.each{ |attr, val| instance_variable_set("@#{attr}".to_sym, val) }
+      parsed_hash.each { |attr, val| instance_variable_set("@#{attr}".to_sym, val) }
     end
 
     attr_reader :domain, :type, :subtype, :identifier, :label
@@ -54,7 +54,7 @@ module CollectionSpace
     # As of v0.13.1, this is equivalent to calling RefName.parse('refnamevalue', :hash)
     # This was added to simplify the process of updating existing code that expects a hash when calling RefName.parse
     def to_h
-      instance_variables.map{ |var| [var.to_s.delete_prefix('@').to_sym, instance_variable_get(var)] }.to_h
+      instance_variables.map { |var| [var.to_s.delete_prefix('@').to_sym, instance_variable_get(var)] }.to_h
     end
   end
 end

--- a/lib/collectionspace/client/version.rb
+++ b/lib/collectionspace/client/version.rb
@@ -2,6 +2,6 @@
 
 module CollectionSpace
   class Client
-    VERSION = '0.12.1'
+    VERSION = '0.13.1'
   end
 end

--- a/lib/collectionspace/client/version.rb
+++ b/lib/collectionspace/client/version.rb
@@ -2,6 +2,6 @@
 
 module CollectionSpace
   class Client
-    VERSION = '0.12.0'
+    VERSION = '0.12.1'
   end
 end

--- a/spec/collectionspace/refname_spec.rb
+++ b/spec/collectionspace/refname_spec.rb
@@ -3,95 +3,131 @@
 require 'spec_helper'
 
 describe CollectionSpace::RefName do
-  let(:refname_collectionobject) do
-    "urn:cspace:core.collectionspace.org:collectionobjects:id(09f531bd-4f12-4c36-9f92)'Loaned object 1'"
-  end
-  let(:refname_procedure) do
-    'urn:cspace:core.collectionspace.org:acquisitions:id(5043d8cc-9437-4bc7-92d1)'
-  end
-  let(:refname_relation) do
-    'urn:cspace:core.collectionspace.org:relations:id(da044bc2-9fbf-474d-803a)'
-  end
-  let(:refname_authority) do
-    "urn:cspace:core.collectionspace.org:personauthorities:name(person)'Local Persons'"
-  end
-  let(:refname_person) do
+  let(:result) { CollectionSpace::RefName.parse(refname, :refname_obj) }
+  let(:result_as_hash) { CollectionSpace::RefName.parse(refname) }
+  let(:refname) do
     "urn:cspace:core.collectionspace.org:personauthorities:name(person):item:name(1234561562130996026)'123456'"
   end
-  let(:refname_with_colon_in_name) do
-    "urn:cspace:core.collectionspace.org:locationauthorities:name(location):item:name(AR1U1Shelf14078111602)'A:R1:U1:Shelf 1'"
-  end
-  let(:refname_with_parens) do
-    "urn:cspace:core.collectionspace.org:conceptauthorities:name(concept):item:name(JMAlexanderCompanyAtlantaGa1028284796)'J.M. Alexander & Company (Atlanta, Ga.)'"
+
+  describe '.parse' do
+    context 'with :refname_obj passed in as return_class' do
+      it 'returns a parsed RefName object' do
+        expect(result).to be_a(CollectionSpace::RefName)
+      end
+    end
+
+    context 'with collectionobject refname' do
+      let(:refname) do
+        "urn:cspace:core.collectionspace.org:collectionobjects:id(09f531bd-4f12-4c36-9f92)'Loaned object 1'"
+      end
+      
+      it 'parses as expected' do
+        expect(result_as_hash).to eq({
+          domain: 'core.collectionspace.org',
+          type: 'collectionobjects',
+          subtype: nil,
+          identifier: '09f531bd-4f12-4c36-9f92',
+          label: 'Loaned object 1'
+        })
+      end
+    end
+
+    context 'with procedure refname' do
+      let(:refname) do
+        'urn:cspace:core.collectionspace.org:acquisitions:id(5043d8cc-9437-4bc7-92d1)'
+      end
+
+      it 'parses as expected' do
+        expect(result_as_hash).to eq({
+          domain: 'core.collectionspace.org',
+          type: 'acquisitions',
+          subtype: nil,
+          identifier: '5043d8cc-9437-4bc7-92d1',
+          label: nil
+        })
+      end
+    end
+
+    context 'with relation refname' do
+      let(:refname) do
+        'urn:cspace:core.collectionspace.org:relations:id(da044bc2-9fbf-474d-803a)'
+      end
+
+      it 'parses as expected' do
+        expect(result_as_hash).to eq({
+          domain: 'core.collectionspace.org',
+          type: 'relations',
+          subtype: nil,
+          identifier: 'da044bc2-9fbf-474d-803a',
+          label: nil
+        })
+      end
+    end
+
+    context 'with top level authority refname' do
+      let(:refname) do
+        "urn:cspace:core.collectionspace.org:personauthorities:name(person)'Local Persons'"
+      end
+
+      it 'parses as expected' do
+        expect(result_as_hash).to eq({
+          domain: 'core.collectionspace.org',
+          type: 'personauthorities',
+          subtype: 'person',
+          identifier: nil,
+          label: 'Local Persons'
+        })
+      end
+    end
+
+    context 'with authority term refname' do
+      it 'parses as expected' do
+        expect(result_as_hash).to eq({
+          domain: 'core.collectionspace.org',
+          type: 'personauthorities',
+          subtype: 'person',
+          identifier: '1234561562130996026',
+          label: '123456'
+        })
+      end
+    end
+
+    context 'with refname containing colon' do
+      let(:refname) do
+        "urn:cspace:core.collectionspace.org:locationauthorities:name(location):item:name(AR1U1Shelf14078111602)'A:R1:U1:Shelf 1'"
+      end
+
+      it 'parses as expected' do
+        expect(result_as_hash).to eq({
+          domain: 'core.collectionspace.org',
+          type: 'locationauthorities',
+          subtype: 'location',
+          identifier: 'AR1U1Shelf14078111602',
+          label: 'A:R1:U1:Shelf 1'
+        })
+      end
+    end
+
+    context 'with refname containing parentheses' do
+      let(:refname) do
+        "urn:cspace:core.collectionspace.org:conceptauthorities:name(concept):item:name(JMAlexanderCompanyAtlantaGa1028284796)'J.M. Alexander & Company (Atlanta, Ga.)'"
+      end
+
+      it 'parses as expected' do
+        expect(result_as_hash).to eq({
+          domain: 'core.collectionspace.org',
+          type: 'conceptauthorities',
+          subtype: 'concept',
+          identifier: 'JMAlexanderCompanyAtlantaGa1028284796',
+          label: 'J.M. Alexander & Company (Atlanta, Ga.)'
+        })
+      end
+    end
   end
 
-  it 'can parse a collectionobject refname' do
-    expect(CollectionSpace::RefName.parse(refname_collectionobject)).to eq({
-                                                                             domain: 'core.collectionspace.org',
-                                                                             type: 'collectionobjects',
-                                                                             subtype: nil,
-                                                                             identifier: '09f531bd-4f12-4c36-9f92',
-                                                                             label: 'Loaned object 1'
-                                                                           })
-  end
-
-  it 'can parse a procedure refname' do
-    expect(CollectionSpace::RefName.parse(refname_procedure)).to eq({
-                                                                      domain: 'core.collectionspace.org',
-                                                                      type: 'acquisitions',
-                                                                      subtype: nil,
-                                                                      identifier: '5043d8cc-9437-4bc7-92d1',
-                                                                      label: nil
-                                                                    })
-  end
-
-  it 'can parse a relation refname' do
-    expect(CollectionSpace::RefName.parse(refname_relation)).to eq({
-                                                                     domain: 'core.collectionspace.org',
-                                                                     type: 'relations',
-                                                                     subtype: nil,
-                                                                     identifier: 'da044bc2-9fbf-474d-803a',
-                                                                     label: nil
-                                                                   })
-  end
-
-  it 'can parse a top level authority refname' do
-    expect(CollectionSpace::RefName.parse(refname_authority)).to eq({
-                                                                      domain: 'core.collectionspace.org',
-                                                                      type: 'personauthorities',
-                                                                      subtype: 'person',
-                                                                      identifier: nil,
-                                                                      label: 'Local Persons'
-                                                                    })
-  end
-
-  it 'can parse an authority term refname' do
-    expect(CollectionSpace::RefName.parse(refname_person)).to eq({
-                                                                   domain: 'core.collectionspace.org',
-                                                                   type: 'personauthorities',
-                                                                   subtype: 'person',
-                                                                   identifier: '1234561562130996026',
-                                                                   label: '123456'
-                                                                 })
-  end
-
-  it 'can parse an authority term with colon' do
-    expect(CollectionSpace::RefName.parse(refname_with_colon_in_name)).to eq({
-                                                                               domain: 'core.collectionspace.org',
-                                                                               type: 'locationauthorities',
-                                                                               subtype: 'location',
-                                                                               identifier: 'AR1U1Shelf14078111602',
-                                                                               label: 'A:R1:U1:Shelf 1'
-                                                                             })
-  end
-
-  it 'can parse an authority term with parens' do
-    expect(CollectionSpace::RefName.parse(refname_with_parens)).to eq({
-                                                                        domain: 'core.collectionspace.org',
-                                                                        type: 'conceptauthorities',
-                                                                        subtype: 'concept',
-                                                                        identifier: 'JMAlexanderCompanyAtlantaGa1028284796',
-                                                                        label: 'J.M. Alexander & Company (Atlanta, Ga.)'
-                                                                      })
+  describe '#to_h' do
+    it 'returns expected hash' do
+      expect(result.to_h).to eq(result_as_hash)
+    end
   end
 end

--- a/spec/collectionspace/refname_spec.rb
+++ b/spec/collectionspace/refname_spec.rb
@@ -20,15 +20,15 @@ describe CollectionSpace::RefName do
       let(:refname) do
         "urn:cspace:core.collectionspace.org:collectionobjects:id(09f531bd-4f12-4c36-9f92)'Loaned object 1'"
       end
-      
+
       it 'parses as expected' do
         expect(result_as_hash).to eq({
-          domain: 'core.collectionspace.org',
-          type: 'collectionobjects',
-          subtype: nil,
-          identifier: '09f531bd-4f12-4c36-9f92',
-          label: 'Loaned object 1'
-        })
+                                       domain: 'core.collectionspace.org',
+                                       type: 'collectionobjects',
+                                       subtype: nil,
+                                       identifier: '09f531bd-4f12-4c36-9f92',
+                                       label: 'Loaned object 1'
+                                     })
       end
     end
 
@@ -39,12 +39,12 @@ describe CollectionSpace::RefName do
 
       it 'parses as expected' do
         expect(result_as_hash).to eq({
-          domain: 'core.collectionspace.org',
-          type: 'acquisitions',
-          subtype: nil,
-          identifier: '5043d8cc-9437-4bc7-92d1',
-          label: nil
-        })
+                                       domain: 'core.collectionspace.org',
+                                       type: 'acquisitions',
+                                       subtype: nil,
+                                       identifier: '5043d8cc-9437-4bc7-92d1',
+                                       label: nil
+                                     })
       end
     end
 
@@ -55,12 +55,12 @@ describe CollectionSpace::RefName do
 
       it 'parses as expected' do
         expect(result_as_hash).to eq({
-          domain: 'core.collectionspace.org',
-          type: 'relations',
-          subtype: nil,
-          identifier: 'da044bc2-9fbf-474d-803a',
-          label: nil
-        })
+                                       domain: 'core.collectionspace.org',
+                                       type: 'relations',
+                                       subtype: nil,
+                                       identifier: 'da044bc2-9fbf-474d-803a',
+                                       label: nil
+                                     })
       end
     end
 
@@ -71,56 +71,56 @@ describe CollectionSpace::RefName do
 
       it 'parses as expected' do
         expect(result_as_hash).to eq({
-          domain: 'core.collectionspace.org',
-          type: 'personauthorities',
-          subtype: 'person',
-          identifier: nil,
-          label: 'Local Persons'
-        })
+                                       domain: 'core.collectionspace.org',
+                                       type: 'personauthorities',
+                                       subtype: 'person',
+                                       identifier: nil,
+                                       label: 'Local Persons'
+                                     })
       end
     end
 
     context 'with authority term refname' do
       it 'parses as expected' do
         expect(result_as_hash).to eq({
-          domain: 'core.collectionspace.org',
-          type: 'personauthorities',
-          subtype: 'person',
-          identifier: '1234561562130996026',
-          label: '123456'
-        })
+                                       domain: 'core.collectionspace.org',
+                                       type: 'personauthorities',
+                                       subtype: 'person',
+                                       identifier: '1234561562130996026',
+                                       label: '123456'
+                                     })
       end
     end
 
     context 'with refname containing colon' do
       let(:refname) do
-        "urn:cspace:core.collectionspace.org:locationauthorities:name(location):item:name(AR1U1Shelf14078111602)'A:R1:U1:Shelf 1'"
+        "urn:cspace:core.collectionspace.org:locationauthorities:name(location):item:name(AR1U1Shelf1)'A:R1:U1:Shelf 1'"
       end
 
       it 'parses as expected' do
         expect(result_as_hash).to eq({
-          domain: 'core.collectionspace.org',
-          type: 'locationauthorities',
-          subtype: 'location',
-          identifier: 'AR1U1Shelf14078111602',
-          label: 'A:R1:U1:Shelf 1'
-        })
+                                       domain: 'core.collectionspace.org',
+                                       type: 'locationauthorities',
+                                       subtype: 'location',
+                                       identifier: 'AR1U1Shelf1',
+                                       label: 'A:R1:U1:Shelf 1'
+                                     })
       end
     end
 
     context 'with refname containing parentheses' do
       let(:refname) do
-        "urn:cspace:core.collectionspace.org:conceptauthorities:name(concept):item:name(JMAlexanderCompanyAtlantaGa1028284796)'J.M. Alexander & Company (Atlanta, Ga.)'"
+        "urn:cspace:core.collectionspace.org:conceptauthorities:name(concept):item:name(JMA)'JMA & Co. (Atlanta, Ga.)'"
       end
 
       it 'parses as expected' do
         expect(result_as_hash).to eq({
-          domain: 'core.collectionspace.org',
-          type: 'conceptauthorities',
-          subtype: 'concept',
-          identifier: 'JMAlexanderCompanyAtlantaGa1028284796',
-          label: 'J.M. Alexander & Company (Atlanta, Ga.)'
-        })
+                                       domain: 'core.collectionspace.org',
+                                       type: 'conceptauthorities',
+                                       subtype: 'concept',
+                                       identifier: 'JMA',
+                                       label: 'JMA & Co. (Atlanta, Ga.)'
+                                     })
       end
     end
   end

--- a/spec/collectionspace/refname_spec.rb
+++ b/spec/collectionspace/refname_spec.rb
@@ -8,6 +8,14 @@ describe CollectionSpace::RefName do
   let(:refname) do
     "urn:cspace:core.collectionspace.org:personauthorities:name(person):item:name(1234561562130996026)'123456'"
   end
+  
+  describe '#new' do
+    let(:result) { CollectionSpace::RefName.new(refname) }
+
+    it 'returns a parsed RefName object' do
+      expect(result).to be_a(CollectionSpace::RefName)
+    end
+  end
 
   describe '.parse' do
     context 'with :refname_obj passed in as return_class' do


### PR DESCRIPTION
**Note: to avoid version numbering weirdness, #22 should be merged (updating version to 0.13.0) before this is merged (updating version to 0.13.1)**

Resolves #21 

What this changes:
- If you call `CollectionSpace::RefName.parse(refname, :refname_obj)`, a RefName object with domain, type, subtype, etc. instance variable attributes is returned. 
- If you do not include the positional `return_class` argument a hash is returned for backward compatibility
- A `to_h` instance method is added to `CollectionSpace::RefName` in case that makes it easier to update existing code to use the parsed RefName object
- Bumps version to 0.13.1 (**Though I went back and forth whether this is adding new functionality at the level that 0.14.0 is more appropriate...**)

Eventually I imagine it would be good to default to returning the parsed RefName object instead of a hash.

If there's a better way to handle this, I'm open to suggestions!