### PR TITLE
Don't define class attributes/methods in `initialize` instance method

### DIFF
--- a/lib/collectionspace/client/configuration.rb
+++ b/lib/collectionspace/client/configuration.rb
@@ -3,39 +3,25 @@
 module CollectionSpace
   # CollectionSpace configuration
   class Configuration
-    class << self
-      def defaults
-        {
-          base_uri: nil,
-          username: nil,
-          password: nil,
-          page_size: 25,
-          include_deleted: false,
-          throttle: 0,
-          verify_ssl: true
-        }
-      end
+    DEFAULTS = {
+      base_uri: nil,
+      username: nil,
+      password: nil,
+      page_size: 25,
+      include_deleted: false,
+      throttle: 0,
+      verify_ssl: true
+    }.freeze
 
-      # The first time a Configuration instance is created, creates `attr_accessor` for each key
-      #   in defaults
-      # Then it undefines and redefines itself as a blank method.
-      # The `undef` is required to avoid 'method redefined' warnings
-      def set_attr_accessors
-        defaults.keys.each{ |setting| send(:attr_accessor, setting) }
-        undef :set_attr_accessors
-        define_singleton_method(:set_attr_accessors){}
-      end
-    end
+    attr_accessor :base_uri, :username, :password, :page_size, :include_deleted, :throttle, :verify_ssl
 
     def initialize(settings = {})
-      settings = self.class.defaults.merge(settings)
+      settings = DEFAULTS.merge(settings)
       settings.each do |property, value|
-        next unless self.class.defaults.key?(property)
+        next unless DEFAULTS.key?(property)
 
         instance_variable_set("@#{property}", value)
       end
-
-      self.class.set_attr_accessors
     end
   end
 end

--- a/lib/collectionspace/client/configuration.rb
+++ b/lib/collectionspace/client/configuration.rb
@@ -15,14 +15,34 @@ module CollectionSpace
       }
     end
 
+    attr_accessor :foo
     def initialize(settings = {})
       settings = defaults.merge(settings)
       settings.each do |property, value|
-        next unless defaults.key? property
+        next unless defaults.key?(property)
 
         instance_variable_set("@#{property}", value)
-        self.class.send(:attr_accessor, property)
+        #self.class.send(:attr_accessor, property)
       end
+
+      attributes = defaults.keys
+      set_class_attrs(attributes) unless class_attrs_exist?(attributes)
+    end
+    
+    private
+
+    def class_attrs_exist?(settings)
+      settings.all?{ |setting| methods.any?(setting) }
+    end
+
+    def set_class_attr(setting)
+      return if [setting, "#{setting}=".to_sym].all?{ |meth| methods.any?(meth) }
+
+      self.class.send(:attr_accessor, setting)
+    end
+    
+    def set_class_attrs(settings)
+      settings.each{ |setting| set_class_attr(setting) }
     end
   end
 end

--- a/lib/collectionspace/client/version.rb
+++ b/lib/collectionspace/client/version.rb
@@ -2,6 +2,6 @@
 
 module CollectionSpace
   class Client
-    VERSION = '0.13.1'
+    VERSION = '0.13.2'
   end
 end


### PR DESCRIPTION
Resolves #27 

`CollectionSpace::Configuration` no longer redefines `attr_accessor` (class) methods with every call of (instance) initialize.

Found a fun, even more "clever" metaprogrammy way to do it, but reverted to just manually listing the `attr_accessors` for clarity/maintainability