### PR TITLE
Development work support additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 .rspec_status
 /tmp/
 collectionobject.rb
+coverage

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,26 @@
+#! /usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'bundler/setup'
+Bundler.require(:tools)
+
+require_relative '../lib/collectionspace/client'
+require 'irb'
+
+module CollectionSpace
+  ::CS = CollectionSpace # alias only in console to minimize typing
+
+  module_function
+
+  def coredev
+    CollectionSpace::Client.new(
+      CollectionSpace::Configuration.new(
+        base_uri: 'https://core.dev.collectionspace.org/cspace-services',
+        username: 'admin@core.collectionspace.org',
+        password: 'Administrator'
+      )
+    )
+  end
+end
+
+IRB.start(__FILE__)

--- a/collectionspace-client.gemspec
+++ b/collectionspace-client.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'vcr'
   spec.add_development_dependency 'webmock'
+  spec.add_development_dependency 'simplecov', '~> 0.21'
 end

--- a/lib/collectionspace/client/version.rb
+++ b/lib/collectionspace/client/version.rb
@@ -2,6 +2,6 @@
 
 module CollectionSpace
   class Client
-    VERSION = '0.13.2'
+    VERSION = '0.13.3'
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'simplecov'
+SimpleCov.start{ enable_coverage :branch }
+
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'collectionspace/client'
 require 'pry'


### PR DESCRIPTION
- Add [simplecov](https://github.com/simplecov-ruby/simplecov)[^1]
- Add `bin/console` command

[^1]: Resulting HTML reports excluded from version control