### PR TITLE
Rewrite `RefName.parse` using StringScanner

### DIFF
--- a/lib/collectionspace/client/version.rb
+++ b/lib/collectionspace/client/version.rb
@@ -2,6 +2,6 @@
 
 module CollectionSpace
   class Client
-    VERSION = '0.13.3'
+    VERSION = '0.13.4'
   end
 end

--- a/spec/collectionspace/refname_spec.rb
+++ b/spec/collectionspace/refname_spec.rb
@@ -98,6 +98,22 @@ describe CollectionSpace::RefName do
           label: '123456'
         })
       end
+
+      context "when label contains '" do
+        let(:refname) do
+          "urn:cspace:core.collectionspace.org:personauthorities:name(person):item:name(JimOMalley1644425338074)'Jim O'Malley'"
+        end
+
+        it 'parses as expected' do
+          expect(result_as_hash).to eq({
+            domain: 'core.collectionspace.org',
+            type: 'personauthorities',
+            subtype: 'person',
+            identifier: 'JimOMalley1644425338074',
+            label: "Jim O'Malley"
+          })
+        end
+      end
     end
 
     context 'with refname containing colon' do

--- a/spec/collectionspace/refname_spec.rb
+++ b/spec/collectionspace/refname_spec.rb
@@ -31,12 +31,12 @@ describe CollectionSpace::RefName do
 
       it 'parses as expected' do
         expect(result_as_hash).to eq({
-                                       domain: 'core.collectionspace.org',
-                                       type: 'collectionobjects',
-                                       subtype: nil,
-                                       identifier: '09f531bd-4f12-4c36-9f92',
-                                       label: 'Loaned object 1'
-                                     })
+          domain: 'core.collectionspace.org',
+          type: 'collectionobjects',
+          subtype: nil,
+          identifier: '09f531bd-4f12-4c36-9f92',
+          label: 'Loaned object 1'
+        })
       end
     end
 
@@ -47,12 +47,12 @@ describe CollectionSpace::RefName do
 
       it 'parses as expected' do
         expect(result_as_hash).to eq({
-                                       domain: 'core.collectionspace.org',
-                                       type: 'acquisitions',
-                                       subtype: nil,
-                                       identifier: '5043d8cc-9437-4bc7-92d1',
-                                       label: nil
-                                     })
+          domain: 'core.collectionspace.org',
+          type: 'acquisitions',
+          subtype: nil,
+          identifier: '5043d8cc-9437-4bc7-92d1',
+          label: nil
+        })
       end
     end
 
@@ -63,12 +63,12 @@ describe CollectionSpace::RefName do
 
       it 'parses as expected' do
         expect(result_as_hash).to eq({
-                                       domain: 'core.collectionspace.org',
-                                       type: 'relations',
-                                       subtype: nil,
-                                       identifier: 'da044bc2-9fbf-474d-803a',
-                                       label: nil
-                                     })
+          domain: 'core.collectionspace.org',
+          type: 'relations',
+          subtype: nil,
+          identifier: 'da044bc2-9fbf-474d-803a',
+          label: nil
+        })
       end
     end
 
@@ -79,40 +79,58 @@ describe CollectionSpace::RefName do
 
       it 'parses as expected' do
         expect(result_as_hash).to eq({
-                                       domain: 'core.collectionspace.org',
-                                       type: 'personauthorities',
-                                       subtype: 'person',
-                                       identifier: nil,
-                                       label: 'Local Persons'
-                                     })
+          domain: 'core.collectionspace.org',
+          type: 'personauthorities',
+          subtype: 'person',
+          identifier: nil,
+          label: 'Local Persons'
+        })
       end
     end
 
     context 'with authority term refname' do
       it 'parses as expected' do
         expect(result_as_hash).to eq({
-                                       domain: 'core.collectionspace.org',
-                                       type: 'personauthorities',
-                                       subtype: 'person',
-                                       identifier: '1234561562130996026',
-                                       label: '123456'
-                                     })
+          domain: 'core.collectionspace.org',
+          type: 'personauthorities',
+          subtype: 'person',
+          identifier: '1234561562130996026',
+          label: '123456'
+        })
       end
     end
 
     context 'with refname containing colon' do
-      let(:refname) do
-        "urn:cspace:core.collectionspace.org:locationauthorities:name(location):item:name(AR1U1Shelf1)'A:R1:U1:Shelf 1'"
+      context 'when authority' do
+        let(:refname) do
+          "urn:cspace:core.collectionspace.org:locationauthorities:name(location):item:name(AR1U1Shelf1)'A:R1:U1:Shelf 1'"
+        end
+
+        it 'parses as expected' do
+          expect(result_as_hash).to eq({
+            domain: 'core.collectionspace.org',
+            type: 'locationauthorities',
+            subtype: 'location',
+            identifier: 'AR1U1Shelf1',
+            label: 'A:R1:U1:Shelf 1'
+          })
+        end
       end
 
-      it 'parses as expected' do
-        expect(result_as_hash).to eq({
-                                       domain: 'core.collectionspace.org',
-                                       type: 'locationauthorities',
-                                       subtype: 'location',
-                                       identifier: 'AR1U1Shelf1',
-                                       label: 'A:R1:U1:Shelf 1'
-                                     })
+      context 'when collectionobject' do
+        let(:refname) do
+          "urn:cspace:cspace.swcenter.fortlewis.edu:collectionobjects:id(4014a62a-30bc-4948-891a)'1958:01001b'"
+        end
+
+        it 'parses as expected' do
+          expect(result_as_hash).to eq({
+            domain: 'cspace.swcenter.fortlewis.edu',
+            type: 'collectionobjects',
+            subtype: nil,
+            identifier: '4014a62a-30bc-4948-891a',
+            label: '1958:01001b'
+          })
+        end
       end
     end
 


### PR DESCRIPTION
Lexically scan and handle the segments of refnames with standard library's StringScanner, rather than complicated regex stuff. 

Resolves #30 