### PR TITLE
Updates `reset_media_blob` helper

### DIFF
--- a/examples/reset_media_blob.rb
+++ b/examples/reset_media_blob.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+require "awesome_print"
+require "collectionspace/client"
+require "csv"
+
+client = CollectionSpace::Client.new(
+  CollectionSpace::Configuration.new(
+    base_uri: "https://core.dev.collectionspace.org/cspace-services",
+    username: "admin@core.collectionspace.org",
+    password: "Administrator"
+  )
+)
+client.config.throttle = 1
+
+path = File.expand_path("~/your/path/here.csv")
+
+CSV.foreach(path, headers: true) do |row|
+  client.reset_media_blob(
+    id: row["identificationnumber"],
+    url: row["mediafileuri"],
+    verbose: true,
+    # client files are on same server as CS instance, and ingestable
+    #   file paths do not all parse as URIs safely
+    ensure_safe_url: false,
+    # This example script used to fix media where the blobs had already
+    #   been deleted, but the blobcsid value was not removed from the
+    #   media record. Attempts to delete the media failed, so this option
+    #   was used to add new blobs without attempting to delete the already
+    #   deleted old blobs (and erroring out)
+    delete_existing_blob: false
+  )
+  sleep 1.5
+end

--- a/spec/collectionspace/helpers_spec.rb
+++ b/spec/collectionspace/helpers_spec.rb
@@ -242,12 +242,14 @@ describe CollectionSpace::Helpers do
 
   describe "#reset_media_blob" do
     let(:client) { default_client }
+    let(:result) { client.reset_media_blob(id: id, url: url) }
+
     context "with an invalid url" do
       let(:id) { "DTS.1" }
       let(:url) { "not_a_url" }
       it "will report an argument error" do
         VCR.use_cassette("helpers_reset_media_blob_invalid_url") do
-          expect { client.reset_media_blob(id, url) }.to raise_error(CollectionSpace::ArgumentError)
+          expect { result }.to raise_error(CollectionSpace::ArgumentError)
         end
       end
     end
@@ -257,7 +259,7 @@ describe CollectionSpace::Helpers do
       let(:url) { "https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png" }
       it "will report a not found error" do
         VCR.use_cassette("helpers_reset_media_blob_does_not_exist") do
-          expect { client.reset_media_blob(id, url) }.to raise_error(CollectionSpace::NotFoundError)
+          expect { result }.to raise_error(CollectionSpace::NotFoundError)
         end
       end
     end
@@ -267,7 +269,7 @@ describe CollectionSpace::Helpers do
       let(:url) { "https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png" }
       it "will report a duplicate id error" do
         VCR.use_cassette("helpers_reset_media_blob_duplicate") do
-          expect { client.reset_media_blob(id, url) }.to raise_error(CollectionSpace::DuplicateIdFound)
+          expect { result }.to raise_error(CollectionSpace::DuplicateIdFound)
         end
       end
     end
@@ -279,9 +281,8 @@ describe CollectionSpace::Helpers do
         VCR.use_cassette("helpers_reset_media_blob_success") do
           response = client.find(type: "media", value: id, field: "identificationNumber")
           blob_csid = response.parsed["abstract_common_list"]["list_item"]["blobCsid"]
-          response = client.reset_media_blob(id, url)
-          expect(response.result.success?).to be true
-          expect(response.parsed["document"]["media_common"]["blobCsid"]).to_not eq blob_csid
+          expect(result.result.success?).to be true
+          expect(result.parsed["document"]["media_common"]["blobCsid"]).to_not eq blob_csid
         end
       end
     end


### PR DESCRIPTION
- Adds optional `verbose` param (default: false). If true, will print tab delimited id/result report to STDOUT
- Adds optional `ensure_safe_url` param (default: true). Can set to false for special cases (non-HTTPS URIs, file paths that do not URI parse correctly, but which ingest ok)
- Adds optional `delete_existing_blob` param (default: true). Can set to false if you deleted blobs another way
- Adds an example script using this method to batch reset a bunch of media blobs in a CSV