### PR TITLE
Add service entry for chronologyauthorities

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    collectionspace-client (0.15.0)
+    collectionspace-client (0.15.1)
       httparty
       json
       nokogiri

--- a/lib/collectionspace/client/service.rb
+++ b/lib/collectionspace/client/service.rb
@@ -12,6 +12,12 @@ module CollectionSpace
           path: "acquisitions",
           term: nil
         },
+        "chronologyauthorities" => {
+          identifier: "shortIdentifier",
+          ns_prefix: "chronologies",
+          path: "chronologyauthorities/urn:cspace:name(#{subtype})/items",
+          term: "chronologie#{TERM_SUFFIX}"
+        },
         "citationauthorities" => {
           identifier: "shortIdentifier",
           ns_prefix: "citations",

--- a/lib/collectionspace/client/service.rb
+++ b/lib/collectionspace/client/service.rb
@@ -16,7 +16,7 @@ module CollectionSpace
           identifier: "shortIdentifier",
           ns_prefix: "chronologies",
           path: "chronologyauthorities/urn:cspace:name(#{subtype})/items",
-          term: "chronologie#{TERM_SUFFIX}"
+          term: "chronology#{TERM_SUFFIX}"
         },
         "citationauthorities" => {
           identifier: "shortIdentifier",

--- a/lib/collectionspace/client/version.rb
+++ b/lib/collectionspace/client/version.rb
@@ -2,6 +2,6 @@
 
 module CollectionSpace
   class Client
-    VERSION = "0.15.0"
+    VERSION = "0.15.1"
   end
 end


### PR DESCRIPTION
CSV Importer cannot import chronology authority data until we define the chronologiesauthority service here.

CSV Importer needs to be updated to use new version of client, but it's currently version pinned to collectionspace-client 0.14.1. 