### PR TITLE
Some updates for the reindex job

### DIFF
--- a/lib/collectionspace/client/helpers.rb
+++ b/lib/collectionspace/client/helpers.rb
@@ -111,7 +111,7 @@ module CollectionSpace
 
     def reindex_full_text(doctype = nil, csids = [])
       run_job(
-        "Reindexing full text",
+        "Reindex Full Text",
         :reindex_full_text,
         :reindex,
         {doctype: doctype, csids: csids}

--- a/lib/collectionspace/client/templates/reindex_full_text.xml.erb
+++ b/lib/collectionspace/client/templates/reindex_full_text.xml.erb
@@ -11,11 +11,8 @@
     <createsNewFocus>false</createsNewFocus>
     <forDocTypes>
       <forDocType>Acquisition</forDocType>
-      <forDocType>Batch</forDocType>
-      <forDocType>Blob</forDocType>
       <forDocType>Citation</forDocType>
       <forDocType>Citationauthority</forDocType>
-      <forDocType>Claim</forDocType>
       <forDocType>CollectionObject</forDocType>
       <forDocType>Conceptauthority</forDocType>
       <forDocType>Conceptitem</forDocType>
@@ -32,7 +29,6 @@
       <forDocType>ObjectExit</forDocType>
       <forDocType>Organization</forDocType>
       <forDocType>Orgauthority</forDocType>
-      <forDocType>Osteology</forDocType>
       <forDocType>Person</forDocType>
       <forDocType>Personauthority</forDocType>
       <forDocType>Placeauthority</forDocType>
@@ -45,7 +41,6 @@
       <forDocType>Vocabulary</forDocType>
       <forDocType>Vocabularyitem</forDocType>
       <forDocType>Workauthority</forDocType>
-      <forDocType>Workitem</forDocType>
     </forDocTypes>
   </ns2:batch_common>
 </document>

--- a/spec/collectionspace/response_spec.rb
+++ b/spec/collectionspace/response_spec.rb
@@ -3,4 +3,86 @@
 require "spec_helper"
 
 describe CollectionSpace::Response do
+  let :response do
+    result = OpenStruct.new(
+      code: 200,
+      body: "",
+      success?: true,
+      parsed_response: {
+        "abstract_common_list" =>
+          {
+            "pageNum" => "0",
+            "pageSize" => "100",
+            "itemsInPage" => "4",
+            "totalItems" => "4",
+            "fieldsReturned" => "csid|uri|refName|updatedAt|workflowState|name|createsNewFocus",
+            "list_item" => [
+              {
+                "csid" => "733c5a43-9094-4bcf-9d7a",
+                "uri" => "/batch/733c5a43-9094-4bcf-9d7a",
+                "refName" => "urn:cspace:pacificbonsaimuseum.org:batch:id(733c5a43-9094-4bcf-9d7a)",
+                "updatedAt" => "2024-11-13T17:41:29.494Z",
+                "workflowState" => "project",
+                "name" => "Reindex Full Text",
+                "createsNewFocus" => "false"
+              },
+              {
+                "csid" => "68f65633-1400-4be6-8db8",
+                "uri" => "/batch/68f65633-1400-4be6-8db8",
+                "refName" => "urn:cspace:pacificbonsaimuseum.org:batch:id(68f65633-1400-4be6-8db8)",
+                "updatedAt" => "2023-03-04T03:55:03.875Z",
+                "workflowState" => "project",
+                "name" => "Merge Authority Items",
+                "createsNewFocus" => "false"
+              },
+              {
+                "csid" => "c4ea120f-9e14-42a5-a40f",
+                "uri" => "/batch/c4ea120f-9e14-42a5-a40f",
+                "refName" => "urn:cspace:pacificbonsaimuseum.org:batch:id(c4ea120f-9e14-42a5-a40f)",
+                "updatedAt" => "2023-03-04T03:55:02.920Z",
+                "workflowState" => "project",
+                "name" => "Update Inventory Status",
+                "createsNewFocus" => "false"
+              },
+              {
+                "csid" => "59cecc98-b6e2-4db7-8665",
+                "uri" => "/batch/59cecc98-b6e2-4db7-8665",
+                "refName" => "urn:cspace:pacificbonsaimuseum.org:batch:id(59cecc98-b6e2-4db7-8665)",
+                "updatedAt" => "2023-03-04T03:55:02.437Z",
+                "workflowState" => "project",
+                "name" => "Update Current Location",
+                "createsNewFocus" => "false"
+              }
+            ]
+          }
+      }
+    )
+    CollectionSpace::Response.new(result)
+  end
+
+  it "finds an item by property" do
+    subjects = [
+      {
+        args: ["abstract_common_list", "list_item", "name", "Reindex Full Text"],
+        expected: "733c5a43-9094-4bcf-9d7a"
+      },
+      {
+        args: ["abstract_common_list", "list_item", "name", "Merge Authority Items"],
+        expected: "68f65633-1400-4be6-8db8"
+      },
+      {
+        args: ["abstract_common_list", "list_item", "name", "Update Inventory Status"],
+        expected: "c4ea120f-9e14-42a5-a40f"
+      },
+      {
+        args: ["abstract_common_list", "list_item", "name", "Update Current Location"],
+        expected: "59cecc98-b6e2-4db7-8665"
+      }
+    ]
+
+    subjects.each do |subject|
+      item = response.find(*subject[:args])
+      expect(subject[:expected]).to eq(item["csid"])
+    end
+  end
 end


### PR DESCRIPTION
If a doctype doesn't exist the batch job can't be created.
For now just cut back on the doctypes (Osteology is not in
all profiles and removed record types [very likely] not
impacted by indexing).

Reset the reindex job name. If the job has already been
created it cannot be created again with a different name
for whatever reason (which is what the client attempts
to do if the name does not match).

Slightly expanded test coverage for CSpace Response.
